### PR TITLE
shared lock: support rollback/resolve, add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20251117073412-2e490904c6bd
+	github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c h1:CgbKAHto5CQgW
 github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c/go.mod h1:4qGtCB0QK0wBzKtFEGDhxXnSnbQApw1gc9siScUl8ew=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20251117073412-2e490904c6bd h1:UNeUFCljoBp58yNbOceJnt5yH75ng1wLzvGvZxWGg0c=
-github.com/pingcap/kvproto v0.0.0-20251117073412-2e490904c6bd/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0 h1:y55aejJQqB1sSpPJ7HP/zRJU4WUsuUhrwv34KVFEkTM=
+github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20251105064658-e1e6b2a1e664
+	github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0
 	github.com/pingcap/tidb v1.1.0-beta.0.20250106104940-3ac9806e2a76
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -361,8 +361,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20251105064658-e1e6b2a1e664 h1:ZPUaaMz+HD5glHBDRrmTAv91Wcp/fj/CtZ/oU/wuixM=
-github.com/pingcap/kvproto v0.0.0-20251105064658-e1e6b2a1e664/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0 h1:y55aejJQqB1sSpPJ7HP/zRJU4WUsuUhrwv34KVFEkTM=
+github.com/pingcap/kvproto v0.0.0-20251120123846-99dcd0a331b0/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20240314023424-862ccc32f18d h1:y3EueKVfVykdpTyfUnQGqft0ud+xVFuCdp1XkVL0X1E=

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tikv_test
 
 import (

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -1,0 +1,229 @@
+package tikv_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/stretchr/testify/suite"
+	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/testutils"
+	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
+)
+
+func TestSharedLock(t *testing.T) {
+	suite.Run(t, new(testSharedLockSuite))
+}
+
+type testSharedLockSuite struct {
+	suite.Suite
+	cluster testutils.Cluster
+	store   tikv.StoreProbe
+}
+
+func (s *testSharedLockSuite) SetupSuite() {
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 3000) // 3s
+	atomic.StoreUint64(&transaction.CommitMaxBackoff, 1000)
+	s.Nil(failpoint.Enable("tikvclient/injectLiveness", `return("reachable")`))
+}
+
+func (s *testSharedLockSuite) TearDownSuite() {
+	s.Nil(failpoint.Disable("tikvclient/injectLiveness"))
+	atomic.StoreUint64(&transaction.CommitMaxBackoff, 20000)
+}
+
+func (s *testSharedLockSuite) SetupTest() {
+	s.store = tikv.StoreProbe{NewTestStore(s.T())}
+	// client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	// s.Require().Nil(err)
+	// testutils.BootstrapWithMultiRegions(cluster, []byte("a"), []byte("b"), []byte("c"))
+	// s.cluster = cluster
+	// pdCli := tikv.NewCodecPDClient(tikv.ModeTxn, pdClient)
+	// spkv := tikv.NewMockSafePointKV()
+	// store, err := tikv.NewKVStore("mocktikv-store", pdCli, spkv, client)
+	// store.EnableTxnLocalLatches(8096)
+	// s.Require().Nil(err)
+	// s.store = tikv.StoreProbe{KVStore: store}
+}
+
+func (s *testSharedLockSuite) TearDownTest() {
+	s.store.Close()
+}
+
+func (s *testSharedLockSuite) begin() transaction.TxnProbe {
+	txn, err := s.store.Begin()
+	s.Require().Nil(err)
+	txn.SetPessimistic(true)
+	return txn
+}
+
+func (s *testSharedLockSuite) getTS() uint64 {
+	ts, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{})
+	s.Nil(err)
+	return ts
+}
+
+func (s *testSharedLockSuite) loadLock(key []byte) *txnlock.Lock {
+	locks, err := s.store.ScanLocks(context.Background(), key, append(key, 0), s.getTS())
+	s.Nil(err)
+	if len(locks) == 0 {
+		return nil
+	}
+	return locks[0]
+}
+
+func (s *testSharedLockSuite) TestSharedLockBlockExclusiveLock() {
+	for _, commit := range []bool{true, false} {
+		txn1 := s.begin()
+		txn2 := s.begin()
+		txn3 := s.begin()
+
+		pk1 := []byte("shared_lock_pk1")
+		pk2 := []byte("shared_lock_pk2")
+		pk3 := []byte("shared_lock_pk3")
+		key := []byte("shared_lock_key")
+
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)
+		lockctx1 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockctx1.InShareMode = true
+		s.Nil(txn1.LockKeys(context.Background(), lockctx1, key))
+
+		s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
+		lockctx2 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockctx2.InShareMode = true
+		fmt.Println(lockctx2.ForUpdateTS)
+		s.Nil(txn2.LockKeys(context.Background(), lockctx2, key))
+
+		flags, err := txn2.GetMemBuffer().GetFlags(key)
+		s.Nil(err)
+		s.True(flags.HasLockedInShareMode())
+
+		s.Nil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk3))
+		s.Equal(txn3.GetCommitter().GetPrimaryKey(), pk3)
+		lockDone := make(chan time.Time)
+		go func() {
+			s.NotNil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key)) // should block and return conflict
+			lockDone <- time.Now()
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+		beforeRelease := time.Now()
+
+		if commit {
+			s.Nil(txn1.Commit(context.Background()))
+			s.Nil(txn2.Commit(context.Background()))
+		} else {
+			s.Nil(txn1.Rollback())
+			s.Nil(txn2.Rollback())
+		}
+
+		afterRelease := <-lockDone
+		s.True(afterRelease.After(beforeRelease), "txn3(exclusive lock) should block until txn1(shared lock) and txn2(shared lock) commit")
+		s.Nil(txn3.Rollback())
+	}
+}
+
+func (s *testSharedLockSuite) TestExclusiveLockBlockSharedLock() {
+	for _, commit := range []bool{true, false} {
+		txn1 := s.begin()
+		txn2 := s.begin()
+		txn3 := s.begin()
+
+		pk1 := []byte("exclusive_lock_pk1")
+		pk2 := []byte("exclusive_lock_pk2")
+		pk3 := []byte("exclusive_lock_pk2")
+		key := []byte("exclusive_lock_key")
+
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key))
+
+		s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
+		s.Nil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk3))
+		s.Equal(txn3.GetCommitter().GetPrimaryKey(), pk3)
+
+		txn2LockDone := make(chan time.Time)
+		go func() {
+			lockctx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+			lockctx.InShareMode = true
+			s.NotNil(txn2.LockKeys(context.Background(), lockctx, key)) // should block and return conflict
+			txn2LockDone <- time.Now()
+		}()
+		txn3LockDone := make(chan time.Time)
+		go func() {
+			lockctx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+			lockctx.InShareMode = true
+			s.NotNil(txn3.LockKeys(context.Background(), lockctx, key)) // should block and return conflict
+			txn3LockDone <- time.Now()
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+		beforeRelease := time.Now()
+
+		if commit {
+			s.Nil(txn1.Commit(context.Background()))
+		} else {
+			s.Nil(txn1.Rollback())
+		}
+
+		txn2Locked := <-txn2LockDone
+		txn3Locked := <-txn3LockDone
+		s.True(txn2Locked.After(beforeRelease), "txn2(shared lock) should block until txn1(exclusive lock) commit/rollback")
+		s.True(txn3Locked.After(beforeRelease), "txn3(shared lock) should block until txn1(exclusive lock) commit/rollback")
+		s.Nil(txn2.Rollback())
+		s.Nil(txn3.Rollback())
+	}
+}
+
+func (s *testSharedLockSuite) TestResolveSharedLock() {
+	txn1 := s.begin()
+
+	pk := []byte("shared_lock_pk")
+	key := []byte("shared_lock_key")
+
+	_, err := s.store.SplitRegions(context.Background(), [][]byte{pk}, false, nil)
+	s.Nil(err)
+
+	s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk))
+	s.Equal(pk, txn1.GetCommitter().GetPrimaryKey())
+	lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+	lockCtx.InShareMode = true
+	s.Nil(txn1.LockKeys(context.Background(), lockCtx, key))
+
+	s.Nil(failpoint.Enable("tikvclient/beforeCommitSecondaries", `return("skip")`))
+	txn1.SetSessionID(1)
+	s.Nil(txn1.Commit(context.Background()))
+
+	lock := s.loadLock(key)
+	s.NotNil(lock)
+	s.Equal(key, lock.Key)
+	s.Equal(pk, lock.Primary)
+
+	s.Equal(txn1.StartTS(), lock.TxnID)
+	s.True(lock.IsShared())
+
+	txn2 := s.begin()
+	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk))
+	s.Equal(pk, txn2.GetCommitter().GetPrimaryKey())
+	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key))
+
+	lock = s.loadLock(key)
+	s.NotNil(lock)
+	s.Equal(key, lock.Key)
+	s.Equal(pk, lock.Primary)
+	s.Equal(txn2.StartTS(), lock.TxnID)
+	s.False(lock.IsShared())
+
+	s.Nil(txn2.Rollback())
+	s.Nil(s.loadLock(key))
+	s.Nil(failpoint.Disable("tikvclient/beforeCommitSecondaries"))
+}

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -71,13 +71,13 @@ func (s *testSharedLockSuite) getTS() uint64 {
 	return ts
 }
 
-func (s *testSharedLockSuite) loadLock(key []byte) *txnlock.Lock {
-	locks, err := s.store.ScanLocks(context.Background(), key, append(key, 0), s.getTS())
+func (s *testSharedLockSuite) scanLocks(key []byte, maxTS uint64) []*txnlock.Lock {
+	locks, err := s.store.ScanLocks(context.Background(), key, append(key, 0), maxTS)
 	s.Nil(err)
 	if len(locks) == 0 {
 		return nil
 	}
-	return locks[0]
+	return locks
 }
 
 func (s *testSharedLockSuite) TestSharedLockBlockExclusiveLock() {
@@ -101,7 +101,6 @@ func (s *testSharedLockSuite) TestSharedLockBlockExclusiveLock() {
 		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
 		lockctx2 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
 		lockctx2.InShareMode = true
-		fmt.Println(lockctx2.ForUpdateTS)
 		s.Nil(txn2.LockKeys(context.Background(), lockctx2, key))
 
 		flags, err := txn2.GetMemBuffer().GetFlags(key)
@@ -205,8 +204,9 @@ func (s *testSharedLockSuite) TestResolveSharedLock() {
 	txn1.SetSessionID(1)
 	s.Nil(txn1.Commit(context.Background()))
 
-	lock := s.loadLock(key)
-	s.NotNil(lock)
+	locks := s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	lock := locks[0]
 	s.Equal(key, lock.Key)
 	s.Equal(pk, lock.Primary)
 
@@ -218,7 +218,9 @@ func (s *testSharedLockSuite) TestResolveSharedLock() {
 	s.Equal(pk, txn2.GetCommitter().GetPrimaryKey())
 	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key))
 
-	lock = s.loadLock(key)
+	locks = s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	lock = locks[0]
 	s.NotNil(lock)
 	s.Equal(key, lock.Key)
 	s.Equal(pk, lock.Primary)
@@ -226,6 +228,99 @@ func (s *testSharedLockSuite) TestResolveSharedLock() {
 	s.False(lock.IsShared())
 
 	s.Nil(txn2.Rollback())
-	s.Nil(s.loadLock(key))
+	s.Len(s.scanLocks(key, s.getTS()), 0)
 	s.Nil(failpoint.Disable("tikvclient/beforeCommitSecondaries"))
+}
+
+func (s *testSharedLockSuite) TestScanSharedLock() {
+	pk1 := []byte("shared_lock_pk_1")
+	pk2 := []byte("shared_lock_pk_2")
+	pk3 := []byte("shared_lock_pk_3")
+	sharedKey := []byte("shared_lock_key")
+	txn1 := s.begin()
+	txn2 := s.begin()
+	txn3 := s.begin()
+
+	pks := [][]byte{pk1, pk2, pk3}
+	txns := []transaction.TxnProbe{txn1, txn2, txn3}
+
+	for i, txn := range txns {
+		s.Nil(txn.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pks[i]))
+		s.Equal(pks[i], txn.GetCommitter().GetPrimaryKey())
+		lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockCtx.InShareMode = true
+		s.Nil(txn.LockKeys(context.Background(), lockCtx, sharedKey))
+	}
+
+	maxTS2LockNum := map[uint64]int{
+		txn1.StartTS() - 1: 0,
+		txn1.StartTS():     1,
+		txn2.StartTS():     2,
+		txn3.StartTS():     3,
+	}
+	for maxTS, lockNum := range maxTS2LockNum {
+		locks := s.scanLocks(sharedKey, maxTS)
+		s.Equal(len(locks), lockNum, fmt.Sprintf("when maxTS=%d, expect %d locks", maxTS, lockNum))
+		for _, lock := range locks {
+			s.Equal(sharedKey, lock.Key)
+			s.LessOrEqual(lock.TxnID, maxTS)
+		}
+	}
+
+	for _, txn := range txns {
+		s.Nil(txn.Rollback())
+	}
+	locks, err := s.store.ScanLocks(context.Background(), sharedKey, append(sharedKey, 0), txn3.StartTS())
+	s.Nil(err)
+	s.Equal(len(locks), 0, "no locks after rollback")
+}
+
+func (s *testSharedLockSuite) TestGCSharedLock() {
+	originManagedLockTTL := atomic.LoadUint64(&transaction.ManagedLockTTL)
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 100) // 100ms
+	defer atomic.StoreUint64(&transaction.ManagedLockTTL, originManagedLockTTL)
+
+	txn1 := s.begin()
+	txn2 := s.begin()
+	txn3 := s.begin()
+	pk1 := []byte("shared_lock_gc_pk1")
+	pk2 := []byte("shared_lock_gc_pk2")
+	pk3 := []byte("shared_lock_gc_pk3")
+	sharedKey := []byte("shared_lock_gc_key")
+
+	pks := [][]byte{pk1, pk2, pk3}
+	txns := []transaction.TxnProbe{txn1, txn2, txn3}
+
+	for i, txn := range txns {
+		s.Nil(txn.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pks[i]))
+		s.Equal(pks[i], txn.GetCommitter().GetPrimaryKey())
+		lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockCtx.InShareMode = true
+		s.Nil(txn.LockKeys(context.Background(), lockCtx, sharedKey))
+	}
+	// keep heartbeat for txn3 only
+	txn1.GetCommitter().CloseTTLManager()
+	txn2.GetCommitter().CloseTTLManager()
+
+	locks := s.scanLocks(sharedKey, s.getTS())
+	s.Len(locks, 3)
+	for _, lock := range locks {
+		s.Equal(sharedKey, lock.Key)
+		s.True(lock.IsShared())
+	}
+
+	// wait managed lock ttl to expire
+	time.Sleep(time.Duration(atomic.LoadUint64(&transaction.ManagedLockTTL))*time.Millisecond + 200*time.Millisecond)
+
+	lr := s.store.NewLockResolver()
+	bo := tikv.NewGcResolveLockMaxBackoffer(context.Background())
+	ttl, err := lr.ResolveLocks(bo, 0, locks)
+	s.Nil(err)
+	s.Zero(ttl)
+
+	locks = s.scanLocks(sharedKey, s.getTS())
+	s.Len(locks, 1)
+	s.Equal(txn3.StartTS(), locks[0].TxnID)
+	s.Equal(sharedKey, locks[0].Key)
+	s.Nil(txn3.Rollback())
 }

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/oracle"
-	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
@@ -23,8 +22,7 @@ func TestSharedLock(t *testing.T) {
 
 type testSharedLockSuite struct {
 	suite.Suite
-	cluster testutils.Cluster
-	store   tikv.StoreProbe
+	store tikv.StoreProbe
 }
 
 func (s *testSharedLockSuite) SetupSuite() {
@@ -39,17 +37,7 @@ func (s *testSharedLockSuite) TearDownSuite() {
 }
 
 func (s *testSharedLockSuite) SetupTest() {
-	s.store = tikv.StoreProbe{NewTestStore(s.T())}
-	// client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
-	// s.Require().Nil(err)
-	// testutils.BootstrapWithMultiRegions(cluster, []byte("a"), []byte("b"), []byte("c"))
-	// s.cluster = cluster
-	// pdCli := tikv.NewCodecPDClient(tikv.ModeTxn, pdClient)
-	// spkv := tikv.NewMockSafePointKV()
-	// store, err := tikv.NewKVStore("mocktikv-store", pdCli, spkv, client)
-	// store.EnableTxnLocalLatches(8096)
-	// s.Require().Nil(err)
-	// s.store = tikv.StoreProbe{KVStore: store}
+	s.store = tikv.StoreProbe{KVStore: NewTestStore(s.T())}
 }
 
 func (s *testSharedLockSuite) TearDownTest() {
@@ -84,9 +72,9 @@ func (s *testSharedLockSuite) TestSharedLockBlockExclusiveLock() {
 		txn2 := s.begin()
 		txn3 := s.begin()
 
-		pk1 := []byte("shared_lock_pk1")
-		pk2 := []byte("shared_lock_pk2")
-		pk3 := []byte("shared_lock_pk3")
+		pk1 := []byte("pk1")
+		pk2 := []byte("pk2")
+		pk3 := []byte("pk3")
 		key := []byte("shared_lock_key")
 
 		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
@@ -137,10 +125,10 @@ func (s *testSharedLockSuite) TestExclusiveLockBlockSharedLock() {
 		txn2 := s.begin()
 		txn3 := s.begin()
 
-		pk1 := []byte("exclusive_lock_pk1")
-		pk2 := []byte("exclusive_lock_pk2")
-		pk3 := []byte("exclusive_lock_pk2")
-		key := []byte("exclusive_lock_key")
+		pk1 := []byte("pk1")
+		pk2 := []byte("pk2")
+		pk3 := []byte("pk3")
+		key := []byte("shared_lock_key")
 
 		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
 		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)

--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -258,9 +258,16 @@ func scanLocksInOneRegionWithStartKey(bo *retry.Backoffer, store Storage, startK
 			return nil, loc, errors.Errorf("unexpected scanlock error: %s", locksResp)
 		}
 		locksInfo := locksResp.GetLocks()
-		locks = make([]*txnlock.Lock, len(locksInfo))
+		locks = make([]*txnlock.Lock, 0, len(locksInfo))
 		for i := range locksInfo {
-			locks[i] = txnlock.NewLock(locksInfo[i])
+			if sharedLockInfos := locksInfo[i].GetSharedLockInfos(); sharedLockInfos != nil {
+				// expand shared lock into multiple locks, and drop the dummy wrapper lock.
+				for _, sharedLockInfo := range sharedLockInfos {
+					locks = append(locks, txnlock.NewLock(sharedLockInfo))
+				}
+				continue
+			}
+			locks = append(locks, txnlock.NewLock(locksInfo[i]))
 		}
 		return locks, loc, nil
 	}

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -902,8 +902,7 @@ func (txn *KVTxn) collectLockedKeys() [][]byte {
 	var err error
 	for it := buf.IterWithFlags(nil, nil); it.Valid(); err = it.Next() {
 		_ = err
-		flags := it.Flags()
-		if flags.HasLocked() || flags.HasLockedInShareMode() {
+		if it.Flags().HasLocked() {
 			keys = append(keys, it.Key())
 		}
 	}

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -902,7 +902,8 @@ func (txn *KVTxn) collectLockedKeys() [][]byte {
 	var err error
 	for it := buf.IterWithFlags(nil, nil); it.Valid(); err = it.Next() {
 		_ = err
-		if it.Flags().HasLocked() {
+		flags := it.Flags()
+		if flags.HasLocked() || flags.HasLockedInShareMode() {
 			keys = append(keys, it.Key())
 		}
 	}


### PR DESCRIPTION
```
> cd integration_tests && go test --with-tikv=true -timeout 10s -run TestSharedLock .                                 
...
PASS
ok      integration_tests       3.326s
```